### PR TITLE
WIP:  Improve Image Processing Performance

### DIFF
--- a/image_process.py
+++ b/image_process.py
@@ -173,7 +173,7 @@ class ParallelWindowProcessor(ImageProcessor):
 
         - We leverage dask.delayed() to parallelize reading and computing median values.
 
-        - We leverage dask arrays and ensure that our chunk sizes match the jp2 files block size.
+        - We leverage dask arrays for blocked algorithms and ensure that our chunk sizes match the jp2 files block size.
 
 
         The overall approach to Windowed processing is similar to the WindowImageProcessor, however, this class
@@ -282,7 +282,7 @@ class WindowImageProcessor(ImageProcessor):
         super().__init__(**kwargs)
         self.merger = merger
         self.window_size_row = window_size_row
-        self.window_size_column = (0, self.img_rows)
+        self.window_size_column = (0, self.img_cols)
 
     def process(self) -> Dict[str, np.ndarray]:
         with futures.ProcessPoolExecutor(max_workers=3) as executor:

--- a/image_process.py
+++ b/image_process.py
@@ -145,7 +145,7 @@ class MedianMerger(ArrayMerger):
             return np.nan_to_num(filtered, nan=0).astype(arr.dtype)
 
 
-class DaskMedianMerger(ArrayMerger):
+class DMedianMerger(DArrayMerger):
 
     def __init__(self, include_zeros=True):
         self.included_zeros = include_zeros
@@ -192,10 +192,11 @@ class ParallelWindowProcessor(ImageProcessor):
         self.max_num_of_sections = round(self.img_rows / self.std_block_size[0]) - 1  # indexed at zero
         self.merger = merger
 
-    def get_block_windows(self, section_idx: int) -> List[Window]:
+    def get_windows_for_section(self, section_idx: int) -> List[Window]:
         """
+        Generates a list of rasterio.Window() objects per section in a jp2 file.
 
-        :param section_idx:
+        :param section_idx: The section
         :return:
         """
         if section_idx > self.max_num_of_sections:
@@ -234,7 +235,7 @@ class ParallelWindowProcessor(ImageProcessor):
         delayed_results = []
         # Delay reading and computation
         for section_idx in range(1, self.max_num_of_sections + 1):
-            windows = self.get_block_windows(section_idx)
+            windows = self.get_windows_for_section(section_idx)
             multi_version = self.read_chunks_of_arr(path, windows)
             merged = self.compute(multi_version)
             delayed_results.append(merged)

--- a/s2_mosaicker.py
+++ b/s2_mosaicker.py
@@ -34,7 +34,7 @@ def main(tile_id, start_datetime, end_datetime, output_path, combine_method, log
     # Manipulate data
     merger = None
     if combine_method == 'median':
-        merger = MedianMerger()
+        merger = MedianMerger(include_zeros=False)
 
     process = WindowImageProcessor(merger=merger, window_size_row=1000, dest_path=output_path)
     final_imgs = process.process()

--- a/tests/functional/test_integration.py
+++ b/tests/functional/test_integration.py
@@ -89,13 +89,13 @@ def test_find_download_and_process(preview_bucket_prefix, filter_rgb, tmp_path):
 
     dest_path =  f'{tmp_path}/final/'
 
-    w = WindowImageProcessor( img_shape_w=687
-                             , img_shape_h=687
+    w = WindowImageProcessor( img_rows=687
+                             , img_cols=687
                              , red_band_path=red_path
                              , green_band_path=green_path
                              , blue_band_path=blue_path
                              , dest_path= dest_path
-                             , merger=MedianMerger(), window_size_row=100)
+                             , merger=MedianMerger(include_zeros=False), window_size_row=100)
 
     final_images = w.process()
 

--- a/tests/unit/test_image_process.py
+++ b/tests/unit/test_image_process.py
@@ -8,7 +8,8 @@ from rasterio.transform import from_origin
 from rasterio import crs
 
 # lib
-from image_process import MedianMerger, WindowImageProcessor
+from image_process import MedianMerger, WindowImageProcessor, ParrallelWindowProcessor
+
 
 
 class TestMedianMerger:
@@ -122,10 +123,31 @@ def test_windowing(create_img, img, tmp_path):
     process.img_shape_h = img.shape[1]
 
     arr = process.window('blue', f'{tmp_path}/')
-    print(arr)
 
     assert np.all(arr[0, :] == np.array([1,1,1,2,1]))
     assert np.all(arr[1, :] == np.array([2,2,2,2,2]))
     assert np.all(arr[2, :] == np.array([3,3,3,3,3]))
     assert np.all(arr[3, :] == np.array([4,5,5,6,6]))
     assert np.all(arr[4, :] == np.array([2,2,2,2,2]))
+
+
+def test_block_windowing(create_img, img, tmp_path):
+    process = ParrallelWindowProcessor(merger=MedianMerger()
+                                       , window_size_row=2
+                                       , img_shape_w=5
+                                       , img_shape_h=5
+                                       , dest_path=''
+                                       , blue_band_path=f'{tmp_path}/')
+
+    process.img_shape_w = img.shape[0]
+    process.img_shape_h = img.shape[1]
+
+    arr = process.process()
+
+    assert np.all(arr[0, :] == np.array([1,1,1,2,1]))
+    assert np.all(arr[1, :] == np.array([2,2,2,2,2]))
+    assert np.all(arr[2, :] == np.array([3,3,3,3,3]))
+    assert np.all(arr[3, :] == np.array([4,5,5,6,6]))
+    assert np.all(arr[4, :] == np.array([2,2,2,2,2]))
+
+

--- a/tests/unit/test_image_process.py
+++ b/tests/unit/test_image_process.py
@@ -8,7 +8,7 @@ from rasterio.transform import from_origin
 from rasterio import crs
 
 # lib
-from image_process import MedianMerger, WindowImageProcessor, ParrallelWindowProcessor
+from image_process import MedianMerger, WindowImageProcessor, ParallelWindowProcessor
 
 
 
@@ -132,22 +132,20 @@ def test_windowing(create_img, img, tmp_path):
 
 
 def test_block_windowing(create_img, img, tmp_path):
-    process = ParrallelWindowProcessor(merger=MedianMerger()
-                                       , window_size_row=2
-                                       , img_shape_w=5
-                                       , img_shape_h=5
-                                       , dest_path=''
-                                       , blue_band_path=f'{tmp_path}/')
+    process = ParallelWindowProcessor(merger=MedianMerger()
+                                      , window_size_row=2
+                                      , img_shape_w=5
+                                      , img_shape_h=5
+                                      , dest_path=''
+                                      )
 
     process.img_shape_w = img.shape[0]
     process.img_shape_h = img.shape[1]
 
-    arr = process.process()
+    arr = process.delayed_window(f'{tmp_path}/')
 
     assert np.all(arr[0, :] == np.array([1,1,1,2,1]))
     assert np.all(arr[1, :] == np.array([2,2,2,2,2]))
     assert np.all(arr[2, :] == np.array([3,3,3,3,3]))
     assert np.all(arr[3, :] == np.array([4,5,5,6,6]))
     assert np.all(arr[4, :] == np.array([2,2,2,2,2]))
-
-


### PR DESCRIPTION
## Overview 

Note: WIP

Once we have pulled jp2 images, there are two major performance bottlenecks from the original implementation:

1. Computing median values and dealing with 0 intensity values. (CPU intensive)
2. Reading chunks of jp2 images into memory (I/O and memory intensive) 

This PR addresses both of these problems.

## Areas for improvement

- Arbitrary window sizes, does not maximize read performance
- Sequential processing for files and median computations 
- For a window size of 2000, this is roughly 21MBs per jp2 file.   


### Solution 

Add a ```ParallelWindowProcessor``` class. This class offers a number of performance improvements over ```WindowImageProcessor.``` These include:

- Leverage the block size from jp2 files to perform efficient windowed reads. Block reads are most efficient when the windows match the dataset's own block structure.

- Leverage dask.delayed() to parallelize reading and computing median values.

- Leverage dask arrays for blocked algorithms and ensure that our chunk sizes match the jp2 files block size 

More information available in the ParallelWindowProcessor docs. 


### Performance benchmarks

#### Setup

**Inputs**

- 5 jp2 files each in a specific "band directory" 

**Hardware**

- 2015 Mac 
- 2.9 GHz Dual-Core Intel Core i5
- 16 GB 1867 MHz DDR3


####  Performance code

```python
# 3rd party
import click

# lib
from image_process import WindowImageProcessor, MedianMerger, DMedianMerger, ParallelWindowProcessor

@click.command()
@click.argument('TECHNIQUE', default='sequential')
@click.argument('RED_IMG_PATH', default='./tmp/red/')
@click.argument('BLUE_IMG_PATH', default='./tmp/blue/')
@click.argument('GREEN_IMG_PATH', default='./tmp/green/')
def main(technique, red_img_path, blue_img_path, green_img_path):
    if technique == 'sequential':
        process = WindowImageProcessor(merger=MedianMerger()
                                       , red_band_path=red_img_path
                                       , green_band_path=green_img_path
                                       , blue_band_path=blue_img_path
                                       , dest_path='')
        arr = process.process()

    elif technique == 'parallel':
        process = ParallelWindowProcessor(merger=DMedianMerger()
                                   , red_band_path=red_img_path
                                   , green_band_path=green_img_path
                                   , blue_band_path=blue_img_path
                                   , dest_path='')
        arr = process.process()



if __name__ == '__main__':
    main()

```

#### Results

`cmdbench --iterations 3 --print-averages --save-plot=sequential.png python3 ./bench_img_processing.py windowing`

![Screen Shot 2023-02-01 at 5 55 56 PM](https://user-images.githubusercontent.com/6462800/216184770-00183b5f-6e19-49ea-89c6-c461a1d04428.png)


![slow-3](https://user-images.githubusercontent.com/6462800/216184052-0c8676b0-3d70-41a2-8870-fe77538d5946.png)


`cmdbench --iterations 3 --print-averages --save-plot=parallel.png python3 ./bench_img_processing.py parallel`

![Screen Shot 2023-02-01 at 5 56 15 PM](https://user-images.githubusercontent.com/6462800/216184732-0afe336e-f2cf-4ce1-a3e6-dbf532e800e2.png)


![fast-3](https://user-images.githubusercontent.com/6462800/216184007-f3db02cd-72d9-450b-a916-68c12b3880b2.png)

